### PR TITLE
Add news management features

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const { promiseDb } = require('./db');
+
+async function runMigration() {
+  const filePath = path.join(__dirname, 'migrations', 'create_news_table.sql');
+  try {
+    const sql = await fs.promises.readFile(filePath, 'utf8');
+    const connection = await promiseDb.getConnection();
+    await connection.query(sql);
+    connection.release();
+    console.log('Migration executed successfully.');
+  } catch (err) {
+    console.error('Migration failed:', err);
+  }
+  process.exit();
+}
+
+runMigration();

--- a/migrations/create_news_table.sql
+++ b/migrations/create_news_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS news (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    keywords VARCHAR(255),
+    author_id INT NOT NULL
+);

--- a/newsController.js
+++ b/newsController.js
@@ -1,0 +1,27 @@
+const { promiseDb } = require('./db');
+
+async function getAllNews() {
+  const [rows] = await promiseDb.query('SELECT * FROM news ORDER BY created_at DESC');
+  return rows;
+}
+
+async function getNewsById(id) {
+  const [rows] = await promiseDb.query('SELECT * FROM news WHERE id = ?', [id]);
+  return rows[0];
+}
+
+async function createNews({ title, content, keywords, author_id }) {
+  await promiseDb.query(
+    'INSERT INTO news (title, content, keywords, author_id) VALUES (?, ?, ?, ?)',
+    [title, content, keywords, author_id]
+  );
+}
+
+async function updateNews(id, { title, content, keywords }) {
+  await promiseDb.query(
+    'UPDATE news SET title = ?, content = ?, keywords = ? WHERE id = ?',
+    [title, content, keywords, id]
+  );
+}
+
+module.exports = { getAllNews, getNewsById, createNews, updateNews };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "migrate": "node migrate.js"
   },
   "keywords": [
     "pokemon",

--- a/public/css/news.css
+++ b/public/css/news.css
@@ -1,0 +1,31 @@
+.news-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+.news-item {
+  border-bottom: 1px solid var(--border-medium);
+  padding-bottom: var(--spacing-sm);
+}
+.news-item h3 {
+  margin-bottom: 0.5rem;
+}
+.news-meta {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+.news-single {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.news-body {
+  margin-top: var(--spacing-sm);
+}
+.news-admin-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.news-admin-table th, .news-admin-table td {
+  border: 1px solid var(--border-medium);
+  padding: var(--spacing-sm);
+}

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -48,9 +48,9 @@
 
         <% if (account && account.group_id >= 2) { %>
           <div class="admin-btn-container">
-            <a href="/admin/server" class="admin-btn">
-              Painel de Administrador
-            </a>
+            <a href="/admin/server" class="admin-btn">Painel de Administrador</a>
+            <a href="/admin/news/new" class="admin-btn">Escrever Notícia</a>
+            <a href="/admin/news" class="admin-btn">Editar Notícias</a>
           </div>
         <% } %>
 
@@ -59,6 +59,7 @@
             Meu Perfil
           </button>
           <button class="nav-tab" data-tab="tickets">Meus Tickets</button>
+          <button class="nav-tab" data-tab="news">Notícias</button>
         </nav>
 
         <div class="dashboard-tab-content">
@@ -155,6 +156,27 @@
                 </div>
                 <div id="tickets-section">
                   <p>Conteúdo da aba de tickets...</p>
+                </div>
+              </div>
+            </section>
+          </div>
+          <div id="news-tab" class="tab-pane">
+            <section class="dashboard-section full-width-news">
+              <div class="dashboard-section-container">
+                <div class="section-header">
+                  <h2>Notícias</h2>
+                </div>
+                <div class="news-list">
+                  <% if (news && news.length > 0) { %>
+                    <% news.forEach(n => { %>
+                      <article class="news-item">
+                        <h3><a href="/news/<%= n.id %>"><%= n.title %></a></h3>
+                        <p class="news-meta"><%= new Date(n.created_at).toLocaleDateString() %></p>
+                      </article>
+                    <% }) %>
+                  <% } else { %>
+                    <p>Nenhuma notícia encontrada.</p>
+                  <% } %>
                 </div>
               </div>
             </section>

--- a/views/news/admin_list.ejs
+++ b/views/news/admin_list.ejs
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gerenciar Notícias - PokeCamp</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/news.css">
+  <link rel="icon" href="/assets/svg/pokeball.svg" type="image/svg+xml">
+</head>
+<body>
+  <%- include('../partials/header', { user: user }) %>
+  <main class="main-content container">
+    <h2 class="section-title" style="margin-bottom: var(--spacing-md);">Gerenciar Notícias</h2>
+    <table class="news-admin-table">
+      <thead>
+        <tr><th>Título</th><th>Data</th><th>Ações</th></tr>
+      </thead>
+      <tbody>
+        <% if (news && news.length > 0) { %>
+          <% news.forEach(item => { %>
+            <tr>
+              <td><%= item.title %></td>
+              <td><%= new Date(item.created_at).toLocaleDateString() %></td>
+              <td><a href="/admin/news/<%= item.id %>/edit" class="btn btn-secondary btn-sm">Editar</a></td>
+            </tr>
+          <% }) %>
+        <% } else { %>
+          <tr><td colspan="3">Nenhuma notícia cadastrada.</td></tr>
+        <% } %>
+      </tbody>
+    </table>
+  </main>
+  <%- include('../partials/footer') %>
+</body>
+</html>

--- a/views/news/create.ejs
+++ b/views/news/create.ejs
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Criar Notícia - PokeCamp</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/news.css">
+  <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+  <script>
+    tinymce.init({ selector: '#content' });
+  </script>
+</head>
+<body>
+  <%- include('../partials/header', { user: user }) %>
+  <main class="main-content container form-page">
+    <section class="form-card">
+      <h2 class="section-title card-title">Nova Notícia</h2>
+      <% if (errorMessage) { %><div class="alert alert-danger"><%= errorMessage %></div><% } %>
+      <form action="/admin/news/new" method="POST">
+        <div class="form-group">
+          <label for="title">Título:</label>
+          <input type="text" id="title" name="title" required>
+        </div>
+        <div class="form-group">
+          <label for="content">Texto:</label>
+          <textarea id="content" name="content" rows="10" required></textarea>
+        </div>
+        <div class="form-group">
+          <label for="keywords">Palavras-Chave:</label>
+          <input type="text" id="keywords" name="keywords">
+        </div>
+        <button type="submit" class="btn btn-primary">Salvar</button>
+      </form>
+    </section>
+  </main>
+  <%- include('../partials/footer') %>
+</body>
+</html>

--- a/views/news/edit.ejs
+++ b/views/news/edit.ejs
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Editar Notícia - PokeCamp</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/news.css">
+  <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+  <script>
+    tinymce.init({ selector: '#content' });
+  </script>
+</head>
+<body>
+  <%- include('../partials/header', { user: user }) %>
+  <main class="main-content container form-page">
+    <section class="form-card">
+      <h2 class="section-title card-title">Editar Notícia</h2>
+      <% if (errorMessage) { %><div class="alert alert-danger"><%= errorMessage %></div><% } %>
+      <form action="/admin/news/<%= news.id %>/edit" method="POST">
+        <div class="form-group">
+          <label for="title">Título:</label>
+          <input type="text" id="title" name="title" value="<%= news.title %>" required>
+        </div>
+        <div class="form-group">
+          <label for="content">Texto:</label>
+          <textarea id="content" name="content" rows="10" required><%- news.content %></textarea>
+        </div>
+        <div class="form-group">
+          <label for="keywords">Palavras-Chave:</label>
+          <input type="text" id="keywords" name="keywords" value="<%= news.keywords %>">
+        </div>
+        <button type="submit" class="btn btn-primary">Atualizar</button>
+      </form>
+    </section>
+  </main>
+  <%- include('../partials/footer') %>
+</body>
+</html>

--- a/views/news/list.ejs
+++ b/views/news/list.ejs
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= title %> - PokeCamp</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/news.css">
+  <link rel="icon" href="/assets/svg/pokeball.svg" type="image/svg+xml">
+</head>
+<body>
+  <%- include('../partials/header', { user: user }) %>
+  <main class="main-content container">
+    <h2 class="section-title" style="margin-bottom: var(--spacing-md);">Notícias</h2>
+    <div class="news-list">
+      <% if (news && news.length > 0) { %>
+        <% news.forEach(item => { %>
+          <article class="news-item">
+            <h3><a href="/news/<%= item.id %>"><%= item.title %></a></h3>
+            <p class="news-meta"><%= new Date(item.created_at).toLocaleDateString() %></p>
+            <p><%- item.content.substring(0, 150) %>...</p>
+          </article>
+        <% }) %>
+      <% } else { %>
+        <p>Nenhuma notícia encontrada.</p>
+      <% } %>
+    </div>
+  </main>
+  <%- include('../partials/footer') %>
+</body>
+</html>

--- a/views/news/view.ejs
+++ b/views/news/view.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= news.title %> - PokeCamp</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/news.css">
+  <link rel="icon" href="/assets/svg/pokeball.svg" type="image/svg+xml">
+</head>
+<body>
+  <%- include('../partials/header', { user: user }) %>
+  <main class="main-content container">
+    <article class="news-single">
+      <h2><%= news.title %></h2>
+      <p class="news-meta"><%= new Date(news.created_at).toLocaleDateString() %></p>
+      <div class="news-body"><%- news.content %></div>
+    </article>
+  </main>
+  <%- include('../partials/footer') %>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add migrations and a migration runner
- build simple controller for news
- implement routes and views for creating, editing and reading news
- show admin buttons on dashboard and list news in a new tab
- add styles for news pages

## Testing
- `npm run migrate` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6845104c6d5c8323b2a63a35f3c7a290