### PR TITLE
Add hero class and style news forms

### DIFF
--- a/public/css/news.css
+++ b/public/css/news.css
@@ -29,3 +29,82 @@
   border: 1px solid var(--border-medium);
   padding: var(--spacing-sm);
 }
+
+/* Formulários de criação e edição de notícias */
+.form-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - var(--header-height, 80px) - var(--footer-height, 150px));
+  padding: var(--spacing-lg) var(--spacing-md);
+}
+
+.form-card {
+  background-color: var(--bg-panel);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  box-shadow: var(--shadow-panel);
+  max-width: 500px;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.form-card .section-title.card-title {
+  text-align: center;
+  margin-bottom: var(--spacing-sm);
+  color: var(--accent-color-light);
+}
+
+.form-card .section-title.card-title::after {
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--accent-color);
+}
+
+.form-group {
+  text-align: left;
+  width: 100%;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: var(--spacing-xs);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 0.95em;
+}
+
+.form-group input[type="text"],
+.form-group textarea {
+  width: 100%;
+  padding: var(--spacing-sm);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-sm);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 1em;
+  box-shadow: var(--shadow-inset);
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 150px;
+}
+
+.form-group input[type="text"]:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: var(--accent-color-light);
+  box-shadow: var(--shadow-inset), 0 0 0 3px rgba(66, 165, 245, 0.3);
+}
+
+.form-card .btn-primary {
+  width: 100%;
+  margin-top: var(--spacing-sm);
+  font-size: 1.1em;
+  padding: var(--spacing-sm) var(--spacing-md);
+}

--- a/public/css/ranking.css
+++ b/public/css/ranking.css
@@ -1,4 +1,5 @@
-.ranking-hero-section.hero-section {
+.ranking-hero-section.hero-section,
+.ranking-hero-section.hero {
     height: 550px;
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -413,11 +413,24 @@ section { padding: var(--spacing-lg) 0; }
         .server-status-bar .status-item .status-label { font-size: 0.8em; text-align: right;}
 }
 
+.hero,
 .hero-section {
-    padding: 0; position: relative; width: 100%; height: 550px; overflow: hidden;
-    display: flex; justify-content: center; align-items: center;
+    padding: 0;
+    position: relative;
+    width: 100%;
+    height: 550px;
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
-.hero-section.hero-single-slide { display: flex; align-items: center; justify-content: center;}
+
+.hero.hero-single-slide,
+.hero-section.hero-single-slide {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
 .hero-background {
      position: absolute; top: 0; left: 0; right: 0; bottom: 0;
      background-size: cover; background-position: center; background-repeat: no-repeat; z-index: 0;
@@ -471,7 +484,8 @@ section { padding: var(--spacing-lg) 0; }
 }
 
 @media (max-width: 992px) {
-    .hero-section { height: 500px; }
+    .hero-section,
+    .hero { height: 500px; }
     .hero-content-wrapper { flex-direction: column; text-align: center; justify-content: center; padding: var(--spacing-md); gap: var(--spacing-md);}
     .hero-text-content { max-width: 100%; padding-right: 0; text-align: center; height: auto; }
     .hero-text-content h1 { font-size: 2.8em; text-align: center; }
@@ -482,7 +496,8 @@ section { padding: var(--spacing-lg) 0; }
      @keyframes float { 0% { transform: translateX(-50%) translateY(0px); } 50% { transform: translateX(-50%) translateY(-10px); } 100% { transform: translateX(-50%) translateY(0px); } }
 }
 @media (max-width: 576px) {
-    .hero-section { height: 400px; }
+    .hero-section,
+    .hero { height: 400px; }
     .hero-content-wrapper { padding: var(--spacing-sm); gap: var(--spacing-sm); }
     .hero-text-content h1 { font-size: 2em; margin-bottom: var(--spacing-xs);}
     .hero-text-content p { font-size: 0.9em; margin-bottom: var(--spacing-md); }

--- a/views/character.ejs
+++ b/views/character.ejs
@@ -63,7 +63,7 @@
                     return parts.join(' ');
                 }
             %>
-            <section class="hero-section character-hero-section animate-on-scroll">
+            <section class="hero hero-section character-hero-section animate-on-scroll">
                 <div class="hero-background" style="background-image: url('/assets/images/background-4.png');"></div>
                 <div class="hero-overlay"></div>
                 <div class="container hero-content-wrapper">

--- a/views/download.ejs
+++ b/views/download.ejs
@@ -19,7 +19,7 @@
 
     <main class="main-content">
         <!-- 1. Hero Visual - Baseado na estrutura da index -->
-        <section class="hero-section download-hero-section hero-single-slide animate-on-scroll" id="download-hero-section">
+        <section class="hero hero-section download-hero-section hero-single-slide animate-on-scroll" id="download-hero-section">
             <div class="hero-background" style="background-image: url('assets/images/background-4.png');"></div> <!-- Fundo igual da index -->
             <div class="hero-overlay"></div>
             <div class="container hero-content-wrapper">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -14,7 +14,7 @@
     <%- include('partials/header') %>
 
     <main class="main-content">
-        <section class="hero-section hero-single-slide animate-on-scroll" id="hero-section">
+        <section class="hero hero-section hero-single-slide animate-on-scroll" id="hero-section">
             <div class="hero-background" style="background-image: url('assets/images/background-4.png');"></div>
             <div class="hero-overlay"></div>
             <div class="container hero-content-wrapper">

--- a/views/news/create.ejs
+++ b/views/news/create.ejs
@@ -13,7 +13,18 @@
 </head>
 <body>
   <%- include('../partials/header', { user: user }) %>
-  <main class="main-content container form-page">
+  <main class="main-content">
+    <section class="hero hero-single-slide animate-on-scroll" id="news-create-hero">
+      <div class="hero-background" style="background-image: url('/assets/images/background-4.png');"></div>
+      <div class="hero-overlay"></div>
+      <div class="container hero-content-wrapper">
+        <div class="hero-text-content">
+          <h1>Criar Notícia</h1>
+          <p>Compartilhe novidades com a comunidade.</p>
+        </div>
+      </div>
+    </section>
+    <div class="container form-page">
     <section class="form-card">
       <h2 class="section-title card-title">Nova Notícia</h2>
       <% if (errorMessage) { %><div class="alert alert-danger"><%= errorMessage %></div><% } %>
@@ -33,6 +44,7 @@
         <button type="submit" class="btn btn-primary">Salvar</button>
       </form>
     </section>
+    </div>
   </main>
   <%- include('../partials/footer') %>
 </body>

--- a/views/news/edit.ejs
+++ b/views/news/edit.ejs
@@ -13,7 +13,18 @@
 </head>
 <body>
   <%- include('../partials/header', { user: user }) %>
-  <main class="main-content container form-page">
+  <main class="main-content">
+    <section class="hero hero-single-slide animate-on-scroll" id="news-edit-hero">
+      <div class="hero-background" style="background-image: url('/assets/images/background-4.png');"></div>
+      <div class="hero-overlay"></div>
+      <div class="container hero-content-wrapper">
+        <div class="hero-text-content">
+          <h1>Editar Notícia</h1>
+          <p>Atualize as informações publicadas.</p>
+        </div>
+      </div>
+    </section>
+    <div class="container form-page">
     <section class="form-card">
       <h2 class="section-title card-title">Editar Notícia</h2>
       <% if (errorMessage) { %><div class="alert alert-danger"><%= errorMessage %></div><% } %>
@@ -33,6 +44,7 @@
         <button type="submit" class="btn btn-primary">Atualizar</button>
       </form>
     </section>
+    </div>
   </main>
   <%- include('../partials/footer') %>
 </body>

--- a/views/ranking.ejs
+++ b/views/ranking.ejs
@@ -15,7 +15,7 @@
     <%- include('partials/header') %>
 
     <main class="main-content">
-        <section class="hero-section ranking-hero-section hero-single-slide animate-on-scroll" id="ranking-hero-section">
+        <section class="hero hero-section ranking-hero-section hero-single-slide animate-on-scroll" id="ranking-hero-section">
             <div class="hero-background" style="background-image: url('assets/images/background-4.png');"></div>
             <div class="hero-overlay"></div>
             <div class="container hero-content-wrapper">


### PR DESCRIPTION
## Summary
- create generic `.hero` styles and adapt responsive rules
- apply `.hero` class to all hero sections
- update news creation and edition pages with hero section
- style news form elements using site variables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845af03655c8323b2dc89e3cf6ed80d