### PR TITLE
Implement password recovery system

### DIFF
--- a/accountController.js
+++ b/accountController.js
@@ -38,9 +38,16 @@ exports.login = async (req) => {
         }
 
         const user = rows[0];
-        const hashedPassword = sha1(password);
+        let passwordMatches = false;
+        if (user.password.length === 40) {
+            // Antigo hash SHA1
+            passwordMatches = user.password === sha1(password);
+        } else {
+            // Hash bcrypt
+            passwordMatches = await require('bcrypt').compare(password, user.password);
+        }
 
-        if (user.password !== hashedPassword) {
+        if (!passwordMatches) {
             return { success: false, message: 'Credenciais inválidas.' };
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "body-parser": "^2.2.0",
         "ejs": "^3.1.10",
         "express": "^4.21.2",
@@ -16,6 +17,7 @@
         "jquery": "^3.7.1",
         "morgan": "^1.10.0",
         "mysql2": "^3.14.1",
+        "nodemailer": "^7.0.3",
         "select2": "^4.1.0-rc.0"
       },
       "devDependencies": {
@@ -108,6 +110,20 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1182,6 +1198,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
+      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "Helton e Pedro",
   "license": "ISC",
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "body-parser": "^2.2.0",
     "ejs": "^3.1.10",
     "express": "^4.21.2",
@@ -23,6 +24,7 @@
     "jquery": "^3.7.1",
     "morgan": "^1.10.0",
     "mysql2": "^3.14.1",
+    "nodemailer": "^7.0.3",
     "select2": "^4.1.0-rc.0"
   },
   "devDependencies": {

--- a/public/css/recover.css
+++ b/public/css/recover.css
@@ -1,0 +1,22 @@
+.otp-group {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+}
+
+.otp-input {
+    width: 40px;
+    padding: var(--spacing-sm);
+    text-align: center;
+    font-size: 1.2em;
+    border: 1px solid var(--input-border);
+    border-radius: var(--radius-md);
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+}
+
+.otp-input:focus {
+    outline: none;
+    border-color: var(--accent-color-light);
+    box-shadow: var(--shadow-inset), 0 0 0 3px rgba(66,165,245,.3);
+}

--- a/public/js/otp.js
+++ b/public/js/otp.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const inputs = Array.from(document.querySelectorAll('.otp-input'));
+    if (!inputs.length) return;
+    inputs[0].focus();
+
+    inputs.forEach((input, idx) => {
+        input.addEventListener('input', e => {
+            const value = e.target.value.replace(/\D/g, '');
+            e.target.value = value;
+            if (value && idx < inputs.length - 1) {
+                inputs[idx + 1].focus();
+            }
+        });
+
+        input.addEventListener('keydown', e => {
+            if (e.key === 'Backspace' && !e.target.value && idx > 0) {
+                inputs[idx - 1].focus();
+            }
+        });
+    });
+
+    // Handle paste entire code
+    document.getElementById('codeForm').addEventListener('paste', e => {
+        const paste = (e.clipboardData || window.clipboardData).getData('text');
+        if (/^\d{6}$/.test(paste)) {
+            paste.split('').forEach((char, i) => {
+                inputs[i].value = char;
+            });
+            inputs[inputs.length - 1].focus();
+            e.preventDefault();
+        }
+    });
+});

--- a/recoverController.js
+++ b/recoverController.js
@@ -1,0 +1,53 @@
+const crypto = require('crypto');
+const nodemailer = require('nodemailer');
+const bcrypt = require('bcrypt');
+const { promiseDb } = require('./db');
+
+const codes = new Map(); // email -> { code, expires }
+
+// create transporter using ethereal for demo purposes
+let transporterPromise = nodemailer.createTestAccount().then(testAccount => {
+    return nodemailer.createTransport({
+        host: testAccount.smtp.host,
+        port: testAccount.smtp.port,
+        secure: testAccount.smtp.secure,
+        auth: {
+            user: testAccount.user,
+            pass: testAccount.pass
+        }
+    });
+});
+
+async function sendCode(email) {
+    const code = Math.floor(100000 + Math.random() * 900000).toString();
+    const expires = Date.now() + 10 * 60 * 1000; // 10 minutes
+    codes.set(email, { code, expires });
+
+    const transporter = await transporterPromise;
+    const info = await transporter.sendMail({
+        from: 'no-reply@example.com',
+        to: email,
+        subject: 'Código de recuperação',
+        text: `Seu código de recuperação é: ${code}`
+    });
+    return nodemailer.getTestMessageUrl(info);
+}
+
+function verifyCode(email, code) {
+    const entry = codes.get(email);
+    if (!entry) return false;
+    if (Date.now() > entry.expires) {
+        codes.delete(email);
+        return false;
+    }
+    const valid = entry.code === code;
+    if (valid) codes.delete(email);
+    return valid;
+}
+
+async function updatePassword(email, password) {
+    const hash = await bcrypt.hash(password, 10);
+    await promiseDb.query('UPDATE accounts SET password = ? WHERE email = ?', [hash, email]);
+}
+
+module.exports = { sendCode, verifyCode, updatePassword };

--- a/views/recover/request.ejs
+++ b/views/recover/request.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><%= title %> - PokeCamp</title>
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/css/login.css">
+    <link rel="stylesheet" href="/css/recover.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" href="/assets/svg/pokeball.svg" type="image/svg+xml">
+</head>
+<body>
+<%- include('../partials/header', { user: user }) %>
+<main class="main-content container content-container form-page">
+    <section class="form-card">
+        <h2 class="section-title card-title">Recuperar Senha</h2>
+        <% if (errorMessage) { %>
+            <div class="alert alert-danger"><%= errorMessage %></div>
+        <% } %>
+        <% if (successMessage) { %>
+            <div class="alert alert-success"><%= successMessage %></div>
+        <% } %>
+        <form action="/recuperar" method="POST" class="auth-form">
+            <div class="form-group">
+                <label for="email">Email:</label>
+                <input type="email" id="email" name="email" required>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block">Enviar código</button>
+        </form>
+    </section>
+</main>
+<%- include('../partials/footer') %>
+</body>
+</html>

--- a/views/recover/reset.ejs
+++ b/views/recover/reset.ejs
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><%= title %> - PokeCamp</title>
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/css/login.css">
+    <link rel="stylesheet" href="/css/recover.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" href="/assets/svg/pokeball.svg" type="image/svg+xml">
+</head>
+<body>
+<%- include('../partials/header', { user: user }) %>
+<main class="main-content container content-container form-page">
+    <section class="form-card">
+        <h2 class="section-title card-title">Redefinir Senha</h2>
+        <% if (errorMessage) { %>
+            <div class="alert alert-danger"><%= errorMessage %></div>
+        <% } %>
+        <% if (successMessage) { %>
+            <div class="alert alert-success"><%= successMessage %></div>
+        <% } %>
+        <form action="/resetar" method="POST" class="auth-form">
+            <div class="form-group">
+                <label for="password">Nova Senha:</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <div class="form-group">
+                <label for="confirm_password">Confirme a Senha:</label>
+                <input type="password" id="confirm_password" name="confirm_password" required>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block">Salvar</button>
+        </form>
+    </section>
+</main>
+<%- include('../partials/footer') %>
+</body>
+</html>

--- a/views/recover/verify.ejs
+++ b/views/recover/verify.ejs
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><%= title %> - PokeCamp</title>
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/css/login.css">
+    <link rel="stylesheet" href="/css/recover.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" href="/assets/svg/pokeball.svg" type="image/svg+xml">
+</head>
+<body>
+<%- include('../partials/header', { user: user }) %>
+<main class="main-content container content-container form-page">
+    <section class="form-card">
+        <h2 class="section-title card-title">Verifique o Código</h2>
+        <% if (errorMessage) { %>
+            <div class="alert alert-danger"><%= errorMessage %></div>
+        <% } %>
+        <% if (successMessage) { %>
+            <div class="alert alert-success"><%= successMessage %></div>
+        <% } %>
+        <form action="/verificar" method="POST" id="codeForm" class="auth-form">
+            <div class="otp-group">
+                <% for(let i=1;i<=6;i++){ %>
+                    <input type="text" maxlength="1" class="otp-input" name="c<%= i %>" required>
+                <% } %>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block">Confirmar</button>
+        </form>
+    </section>
+</main>
+<%- include('../partials/footer') %>
+<script src="/js/otp.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add nodemailer and bcrypt dependencies
- support bcrypt logins while keeping SHA1 fallback
- implement recovery controller for code generation, verification and password update
- create password recovery routes and EJS views
- add OTP input styles and javascript helpers

## Testing
- `npm install nodemailer bcrypt` *(fails: already installed?)*

------
https://chatgpt.com/codex/tasks/task_e_6845baeb0814832390e98a42d5aa5177